### PR TITLE
Limit logging rate to 1/5s

### DIFF
--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -7,7 +7,7 @@ record(bo, "$(P)DISABLE")
   field(ZNAM, "COMMS ENABLED")
   field(ONAM, "COMMS DISABLED")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 # Enable *very* verbose logging in the state machine.
@@ -26,7 +26,7 @@ record(bo, "$(P)DEBUG")
   field(ONAM, "Debug enabled")  
   field(OSV, "MINOR")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 # Tell the magnetometer to process it's PVs and get new values from hardware. This PV is processed
@@ -80,7 +80,7 @@ record(mbbo, "$(P)STATEMACHINE:STATE") {
   field(TTST, "wait_for_outputs_on")
   
   # Do not archive unless needed for debugging - this PV can change very quickly (~100Hz)
-  # info(archive, "VAL")
+  # info(archive, "5.0 VAL")
 }
 
 record(bo, "$(P)STATEMACHINE:ACTIVITY") {
@@ -99,7 +99,7 @@ record(ao, "$(P)STATEMACHINE:LOOP_TIME") {
   
   # Only log if changes by more than 5ms, otherwise database could fill with small fluctuations.
   field(ADEL, "5")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
   info(interest, "LOW")
 }
@@ -116,7 +116,7 @@ record(ao, "$(P)STATEMACHINE:LOOP_DELAY")
   field(PINI, "YES")
   field(PREC, "0")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(interest, "LOW")
 }
 
@@ -134,7 +134,7 @@ record(ao, "$(P)STATEMACHINE:READ_TIMEOUT")
   field(PINI, "YES")
   field(PREC, "0")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(interest, "LOW")
 }
 
@@ -145,7 +145,7 @@ record(bo, "$(P)STABLE") {
   field(ONAM, "Stable")
   
   info(interest, "HIGH")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
 }
 
@@ -159,7 +159,7 @@ record(bo, "$(P)AUTOFEEDBACK") {
   field(PINI, "YES")
   
   info(interest, "HIGH")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 alias("$(P)AUTOFEEDBACK", "$(P)AUTOFEEDBACK:SP")
@@ -170,7 +170,7 @@ record(ao, "$(P)TOLERANCE") {
   field(PREC, "10")
   
   info(interest, "HIGH")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 record(mbbo, "$(P)STATUS") {
@@ -204,7 +204,7 @@ record(ao, "$(P)P:FEEDBACK") {
   field(PINI, "YES")
   
   info(interest, "HIGH")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 alias("$(P)P:FEEDBACK", "$(P)P:FEEDBACK:SP")
@@ -217,7 +217,7 @@ record(ao, "$(P)OUTPUT:PSU_WRITE_TOLERANCE") {
   field(VAL, "0.0002")
   field(PINI, "YES")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(interest, "LOW")
 }
 
@@ -229,7 +229,7 @@ record(calc, "$(P)FIELD:MAGNITUDE") {
   field(CALC, "SQRT(A*A + B*B + C*C)")
   field(EGU, "mG")
   field(PREC, "2")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
   info(interest, "HIGH")
   field(ASG, "READONLY")
@@ -243,7 +243,7 @@ record(calc, "$(P)FIELD:MAGNITUDE:MEAS") {
   field(CALC, "SQRT(A*A + B*B + C*C)")
   field(EGU, "mG")
   field(PREC, "2")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
   info(interest, "HIGH")
   field(ASG, "READONLY")

--- a/zfcntrlSup/zfcntrl_axis.template
+++ b/zfcntrlSup/zfcntrl_axis.template
@@ -15,7 +15,7 @@ record(calc, "$(P)FIELD:$(AXIS)") {
   field(CALC, "A")
   field(EGU, "mG")
   field(PREC, "2")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(interest, "HIGH")
   info(alarm, "ZFCNTRL")
   field(ASG, "READONLY")
@@ -37,7 +37,7 @@ record(calc, "$(P)FIELD:$(AXIS):MEAS") {
   field(CALC, "A")
   field(EGU, "mG")
   field(PREC, "2")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(interest, "HIGH")
   info(alarm, "ZFCNTRL")
   field(ASG, "READONLY")
@@ -48,7 +48,7 @@ record(ao, "$(P)FIELD:$(AXIS):SP") {
   field(EGU, "mG")
   field(PREC, "2")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 # Proportional feedback factors - axis $(AXIS)
@@ -61,7 +61,7 @@ record(ao, "$(P)P:$(AXIS)") {
   field(PINI, "YES")
   
   info(interest, "HIGH")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 alias("$(P)P:$(AXIS)", "$(P)P:$(AXIS):SP")
@@ -79,7 +79,7 @@ record(ai, "$(P)OUTPUT:$(AXIS):CURR") {
   field(LLSV, "MAJOR")
   
   info(interest, "MEDIUM")
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
 }
 
@@ -112,7 +112,7 @@ record(ai, "$(P)OUTPUT:$(AXIS):CURR:SP:RBV") {
   field(HHSV, "MAJOR")
   field(LLSV, "MAJOR")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
 }
 
@@ -122,7 +122,7 @@ record(bi, "$(P)OUTPUT:$(AXIS):STATUS") {
   field(ZNAM, "Off")
   field(ONAM, "On")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
   info(interest, "LOW")
 }
@@ -137,7 +137,7 @@ record(bo, "$(P)OUTPUT:$(AXIS):STATUS:SP") {
   # may not necessarily cause the record on the other end to process.
   field(FLNK, "$(PSU_$(AXIS)):OUTPUTSTATUS:SP.PROC CA")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 record(bi, "$(P)OUTPUT:$(AXIS):MODE") {
@@ -146,7 +146,7 @@ record(bi, "$(P)OUTPUT:$(AXIS):MODE") {
   field(ZNAM, "Voltage")  field(ZSV, "MAJOR")  # Should never be in Voltage mode for the IOC to work correctly.
   field(ONAM, "Current")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(alarm, "ZFCNTRL")
   info(interest, "LOW")
 }
@@ -161,7 +161,7 @@ record(bo, "$(P)OUTPUT:$(AXIS):MODE:SP") {
   # may not necessarily cause the record on the other end to process.
   field(FLNK, "$(PSU_$(AXIS)):OUTPUTMODE:SP.PROC CA")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 record(ai, "$(P)OUTPUT:$(AXIS):VOLT") {
@@ -170,7 +170,7 @@ record(ai, "$(P)OUTPUT:$(AXIS):VOLT") {
   field(INP, "$(PSU_$(AXIS)):VOLTAGE CPP MSS")
   field(PREC, "6")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
   info(interest, "LOW")
 }
 
@@ -184,7 +184,7 @@ record(ao, "$(P)OUTPUT:$(AXIS):VOLT:SP") {
   # may not necessarily cause the record on the other end to process.
   field(FLNK, "$(PSU_$(AXIS)):VOLTAGE:SP.PROC CA")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }
 
 record(ai, "$(P)OUTPUT:$(AXIS):VOLT:SP:RBV") {
@@ -193,5 +193,5 @@ record(ai, "$(P)OUTPUT:$(AXIS):VOLT:SP:RBV") {
   field(INP, "$(PSU_$(AXIS)):VOLTAGE:SP:RBV CPP MSS")
   field(PREC, "6")
   
-  info(archive, "VAL")
+  info(archive, "5.0 VAL")
 }


### PR DESCRIPTION
Limit the logging rate of the zero-field system to once per 5s.

I think this is a reasonable balance between logging enough for diagnostics, but not necessarily logging too much noise which might fill up the database quickly.