### PR TITLE
Change STABLITY PV to AT_SETPOINT

### DIFF
--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -106,13 +106,19 @@ ss zero_field
     } state check_corrected_field
     
     when(new_readings_available && magnetometer_invalid(pVar)) {
-      PVPUT(stable, 0);
+      if (auto_feedback_enabled) {
+        PVPUT(at_setpoint, 0);
+      }
+
       PVPUT(status, ZF_STAT_MAGNETOMETER_DATA_INVALID);
       errlogSevPrintf(errlogMajor, "%s: Magnetometer read error: new reading became available but severities were invalid.\n", PROGRAM_NAME);
     } state wait_before_read
     
     when(delay(read_timeout)) {
-      PVPUT(stable, 0);
+      if (auto_feedback_enabled) {
+        PVPUT(at_setpoint, 0);
+      }
+
       PVPUT(status, ZF_STAT_MAGNETOMETER_DATA_STALE);
       errlogSevPrintf(errlogMajor, "%s: Magnetometer read error: new reading did not become available.\n", PROGRAM_NAME);
       /* After this state go straight to trigger_mag_read rather than wait_before_read as we have already waited 5 seconds */
@@ -125,16 +131,19 @@ ss zero_field
     }
     
     when() {
-      int within_tolerance = is_within_tolerance(setpoint_x, magnetometer_x, tolerance) && 
-          is_within_tolerance(setpoint_y, magnetometer_y, tolerance) && 
-          is_within_tolerance(setpoint_z, magnetometer_z, tolerance);
-          
-      PVPUT(stable, within_tolerance);
-      
-      if (debug) {
-        errlogSevPrintf(errlogInfo, "%s: Magnetometer within tolerance: %s\n", PROGRAM_NAME, within_tolerance ? "True" : "False");
+      if (!auto_feedback_enabled) {
+        PVPUT(at_setpoint, 2);
+      } else {
+        int within_tolerance = is_within_tolerance(setpoint_x, magnetometer_x, tolerance) &&
+            is_within_tolerance(setpoint_y, magnetometer_y, tolerance) &&
+            is_within_tolerance(setpoint_z, magnetometer_z, tolerance);
+        
+        PVPUT(at_setpoint, within_tolerance);
+        
+        if (debug) {
+          errlogSevPrintf(errlogInfo, "%s: Magnetometer within tolerance: %s\n", PROGRAM_NAME, within_tolerance ? "True" : "False");
+        }
       }
-      
     } state check_raw_field
   }
   

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -110,7 +110,7 @@ PV(double, statemachine_measured_loop_time, "{P}STATEMACHINE:LOOP_TIME", NoMon);
 PV(double, loop_delay, "{P}STATEMACHINE:LOOP_DELAY", Monitor); /* msec */
 PV(double, read_timeout, "{P}STATEMACHINE:READ_TIMEOUT", Monitor); /* sec */
 PV(int, status, "{P}STATUS", NoMon);
-PV(int, stable, "{P}STABLE", Monitor);
+PV(int, at_setpoint, "{P}AT_SETPOINT", Monitor);
 
 /* Whether new readings are available from the magnetometer */
 PV(int, new_readings_available, "{P}_READINGS_READY", Monitor);

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -140,11 +140,12 @@ record(ao, "$(P)STATEMACHINE:READ_TIMEOUT")
   info(interest, "LOW")
 }
 
-record(bo, "$(P)STABLE") {
-  field(DESC, "Stability of ZF system")
-  field(ZNAM, "Unstable")
-  field(ZSV, "MAJOR")
-  field(ONAM, "Stable")
+record(mbbo, "$(P)AT_SETPOINT") {
+  field(DESC, "Is measurement within tolerance of SP")
+  field(ZRST, "No")
+  field(ZRSV, "MAJOR")
+  field(ONST, "Yes")
+  field(TWST, "N/A")
   
   info(interest, "HIGH")
   info(archive, "5.0 VAL")
@@ -167,7 +168,7 @@ record(bo, "$(P)AUTOFEEDBACK") {
 alias("$(P)AUTOFEEDBACK", "$(P)AUTOFEEDBACK:SP")
 
 record(ao, "$(P)TOLERANCE") {
-  field(DESC, "Tolerance for 'stable' field")
+  field(DESC, "Tolerance for 'AT_SETPOINT' field")
   field(EGU, "mG")
   field(PREC, "10")
   

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -145,6 +145,7 @@ record(mbbo, "$(P)AT_SETPOINT") {
   field(ZRST, "No")
   field(ZRSV, "MAJOR")
   field(ONST, "Yes")
+  # N/A is set when autofeedback is off
   field(TWST, "N/A")
   
   info(interest, "HIGH")


### PR DESCRIPTION
### Description of work
Renames the `STABILITY` PV to `AT_SETPOINT`. The new PV is always "N/A" when in manual mode, and "Yes" or "No" when in autofeedback mode depending on whether the measured field is within tolerance of the setpoint or not.

Note that "No" (0) is still an alarm state.

Once this change is merged, the wiki [diagram](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Zero-field-controller-design#implementation) should be updated to this:
![ZFCNTRL_flow_updated](https://user-images.githubusercontent.com/10788760/77631863-15f49b00-6f45-11ea-88a7-caa40c8bb837.png)

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5190

### Acceptance criteria
- The tests in the [linked PR](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/311) pass