### PR TITLE
Add math.h to get correct return type for fabs() 

### DIFF
--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -5,6 +5,7 @@ program zero_field("P")
 %% #include "seq_snc.h"
 %% #include "epicsTime.h"
 %% #include "string.h"
+%% #include "math.h"
 %% #include "errlog.h"
 %% #include "alarm.h"
 


### PR DESCRIPTION
This fixes test failures on debug builds