### PR TITLE
Ticket6722 zf remove wait for tolerance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "*.protocol": "proto",
+        "MacJenkinsfile": "groovy",
+        "*.st": "c"
+    }
+}

--- a/zfcntrlSup/Makefile
+++ b/zfcntrlSup/Makefile
@@ -9,7 +9,7 @@ DBD += zfcntrl.dbd
 
 # Sequence file
 LIBRARY_IOC = zfcntrl
-zfcntrl_SRCS += zero_field.st
+zfcntrl_SRCS += zero_field.st zero_field_setpoint_readback_diagnostics.st
 zfcntrl_LIBS += seq pv
 zfcntrl_LIBS += $(EPICS_BASE_IOC_LIBS)
 

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -336,29 +336,20 @@ ss zero_field
       PVPUT(output_psu_x_sp, coerced_x);
       PVPUT(output_psu_y_sp, coerced_y);
       PVPUT(output_psu_z_sp, coerced_z);
-      
-    } state check_psu_writes
-  }
-  
-  state check_psu_writes {
-      entry {
-        ZF_TRANSITION_TO_STATE("check_psu_writes"); 
+
+      if (_output_on_limit) {
+        PVPUT(status, ZF_STAT_PSU_ON_LIMITS);
+      } else {
+        /* If we get to this state, there has been no error */
+        PVPUT(status, ZF_STAT_NO_ERROR);   
       }
       
-      when() {
-        if (_output_on_limit) {
-          PVPUT(status, ZF_STAT_PSU_ON_LIMITS);
-        } else {
-          /* If we get to this state, there has been no error */
-          PVPUT(status, ZF_STAT_NO_ERROR);   
-        }
-        
-        if (debug) {
-          errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
-		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
-        }
-      } state wait_before_read
+      if (debug) {
+        errlogSevPrintf(errlogInfo, "%s: power supply write set X=%f, Y=%f, Z=%f\n",
+                    PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
+      }
       
+    } state wait_before_read
   }
   
   state wait_before_read {

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -345,12 +345,7 @@ ss zero_field
         ZF_TRANSITION_TO_STATE("check_psu_writes"); 
       }
       
-      when(
-        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
-        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
-        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
-      ) {
-                
+      when() {
         if (_output_on_limit) {
           PVPUT(status, ZF_STAT_PSU_ON_LIMITS);
         } else {
@@ -364,14 +359,6 @@ ss zero_field
         }
       } state wait_before_read
       
-      when(delay(read_timeout)) {
-          PVPUT(status, ZF_STAT_PSU_WRITE_FAILED);
-		  report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
-		  report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
-		  report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
-   
-       /* don't go to wait_before_read in this case as we have already waited 5 seconds */
-      } state trigger_mag_read
   }
   
   state wait_before_read {

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -343,6 +343,8 @@ ss zero_field
         /* If we get to this state, there has been no error */
         PVPUT(status, ZF_STAT_NO_ERROR);   
       }
+
+      PVPUT(check_psu_tolerance, 1);
       
       if (debug) {
         errlogSevPrintf(errlogInfo, "%s: power supply write set X=%f, Y=%f, Z=%f\n",

--- a/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
+++ b/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
@@ -19,7 +19,7 @@ option +s;
 
   /* Some necessary function forward-declarations - for implementations see end of file. */
   static int is_within_tolerance(double setpoint, double readback, double tolerance);
-  static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance, double timeout);
+  static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance);
 
   int new_tolerance_errors = 0;
 }%
@@ -39,18 +39,15 @@ ss zero_field_setpoint_readback_diagnostics
   }
 
   state check_psu_writes {  
+    entry {
+      PVPUT(check_psu_tolerance, 0);
+    }
+
     when(
         is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
         is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
         is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
       ) {
-
-        // if (_output_on_limit) {
-        //   PVPUT(status, ZF_STAT_PSU_ON_LIMITS);
-        // } else {
-        //   /* If we get to this state, there has been no error */
-        //   PVPUT(status, ZF_STAT_NO_ERROR);   
-        // }
         errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
 		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         
@@ -59,15 +56,15 @@ ss zero_field_setpoint_readback_diagnostics
 		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         }
       } state idle
-      
-      when(delay(read_timeout)) {
-          errlogSevPrintf(errlogInfo, "read timeout\n");
-          tolerance_errors += 1;
-          pvPut(tolerance_errors);
-		      report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
-		      report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
-		      report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
-      } state idle
+
+    when(check_psu_tolerance == 1) { 
+        errlogSevPrintf(errlogInfo, "Setpoint-readback failed to get within tolerance of setpoint before a new setpoint was set\n");
+        tolerance_errors += 1;
+        pvPut(tolerance_errors);
+		    report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance);
+		    report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance);
+		    report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance);
+    } state check_psu_writes
   }
 
 }
@@ -84,11 +81,11 @@ ss zero_field_setpoint_readback_diagnostics
   /**
    * Report error if axis out of tolerance
    */
-    static void report_tolerance_error(const char* axis, double sp, double sp_rbv, double tolerance, double timeout)
+    static void report_tolerance_error(const char* axis, double sp, double sp_rbv, double tolerance)
     {
         if (!is_within_tolerance(sp, sp_rbv, tolerance)) {
-            errlogSevPrintf(errlogMajor, "%s: %s Power supply write failed to get within tolerance %f: SP=%f SP:RBV=%f error=%f Timeout=%f\n",
-                          PROGRAM_NAME, axis, tolerance, sp, sp_rbv, sp - sp_rbv, timeout);
+            errlogSevPrintf(errlogMajor, "%s: %s Power supply write failed to get within tolerance %f: SP=%f SP:RBV=%f error=%f\n",
+                          PROGRAM_NAME, axis, tolerance, sp, sp_rbv, sp - sp_rbv);
         }
     }
 }%

--- a/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
+++ b/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
@@ -1,0 +1,98 @@
+program zero_field_setpoint_readback_diagnostics("P")
+
+#include "seqPVmacros.h"
+#include "zf_pv_definitions.h"
+%% #include "seq_snc.h"
+%% #include "epicsTime.h"
+%% #include "string.h"
+%% #include "math.h"
+%% #include "errlog.h"
+%% #include "alarm.h"
+
+option +d;
+option +r;
+option +s;
+
+
+%{
+  static const char* const PROGRAM_NAME = "zero_field_setpoint_readback_diagnostics.st";
+
+  /* Store old values of psu writes to detect changes */
+  double old_output_psu_x_sp = 0;  
+  double old_output_psu_y_sp = 0;  
+  double old_output_psu_z_sp = 0;  
+
+  /* Some necessary function forward-declarations - for implementations see end of file. */
+  static int is_within_tolerance(double setpoint, double readback, double tolerance);
+  static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance, double timeout);
+}%
+
+ss zero_field_setpoint_readback_diagnostics
+{
+  
+  state idle {
+    entry {
+        old_output_psu_x_sp = pvGet(output_psu_x_sp);
+        old_output_psu_y_sp = pvGet(output_psu_y_sp);
+        old_output_psu_z_sp = pvGet(output_psu_z_sp);
+    }
+
+    when( 
+        old_output_psu_x_sp != output_psu_x_sp ||
+        old_output_psu_y_sp != output_psu_y_sp ||
+        old_output_psu_z_sp != output_psu_z_sp
+    ) { } state check_psu_writes
+
+  }
+
+  state check_psu_writes {  
+    when(
+        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
+        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
+        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
+      ) {
+
+        // if (_output_on_limit) {
+        //   PVPUT(status, ZF_STAT_PSU_ON_LIMITS);
+        // } else {
+        //   /* If we get to this state, there has been no error */
+        //   PVPUT(status, ZF_STAT_NO_ERROR);   
+        // }
+        
+        if (debug) {
+          errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
+		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
+        }
+      } state idle
+      
+      when(delay(read_timeout)) {
+          int incremented_tolerance_errors = pvGet(tolerance_errors) + 1;
+          PVPUT(tolerance_errors, incremented_tolerance_errors);
+		  report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
+		  report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
+		  report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
+      } state idle
+  }
+
+}
+
+
+%{ 
+  /**
+   * Returns 1 if the first two arguments are within tolerance of each other, else 0.
+   */
+  static int is_within_tolerance(double setpoint, double readback, double tolerance) {
+    return fabs(setpoint - readback) <= tolerance;
+  }
+  
+  /**
+   * Report error if axis out of tolerance
+   */
+    static void report_tolerance_error(const char* axis, double sp, double sp_rbv, double tolerance, double timeout)
+    {
+        if (!is_within_tolerance(sp, sp_rbv, tolerance)) {
+            errlogSevPrintf(errlogMajor, "%s: %s Power supply write failed to get within tolerance %f: SP=%f SP:RBV=%f error=%f Timeout=%f\n",
+                          PROGRAM_NAME, axis, tolerance, sp, sp_rbv, sp - sp_rbv, timeout);
+        }
+    }
+}%

--- a/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
+++ b/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
@@ -20,6 +20,8 @@ option +s;
   /* Some necessary function forward-declarations - for implementations see end of file. */
   static int is_within_tolerance(double setpoint, double readback, double tolerance);
   static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance, double timeout);
+
+  int new_tolerance_errors = 0;
 }%
 
 ss zero_field_setpoint_readback_diagnostics
@@ -60,7 +62,8 @@ ss zero_field_setpoint_readback_diagnostics
       
       when(delay(read_timeout)) {
           errlogSevPrintf(errlogInfo, "read timeout\n");
-          PVPUT(tolerance_errors, pvGet(tolerance_errors) + 1);
+          new_tolerance_errors = pvGet(tolerance_errors) + 1;
+          PVPUT(tolerance_errors,  new_tolerance_errors);
 		      report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
 		      report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
 		      report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);

--- a/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
+++ b/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
@@ -17,11 +17,6 @@ option +s;
 %{
   static const char* const PROGRAM_NAME = "zero_field_setpoint_readback_diagnostics.st";
 
-  /* Store old values of psu writes to detect changes */
-  double old_output_psu_x_sp = 0;  
-  double old_output_psu_y_sp = 0;  
-  double old_output_psu_z_sp = 0;  
-
   /* Some necessary function forward-declarations - for implementations see end of file. */
   static int is_within_tolerance(double setpoint, double readback, double tolerance);
   static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance, double timeout);
@@ -32,16 +27,12 @@ ss zero_field_setpoint_readback_diagnostics
   
   state idle {
     entry {
-        old_output_psu_x_sp = pvGet(output_psu_x_sp);
-        old_output_psu_y_sp = pvGet(output_psu_y_sp);
-        old_output_psu_z_sp = pvGet(output_psu_z_sp);
+      PVPUT(check_psu_tolerance, 0);
     }
 
-    when( 
-        old_output_psu_x_sp != output_psu_x_sp ||
-        old_output_psu_y_sp != output_psu_y_sp ||
-        old_output_psu_z_sp != output_psu_z_sp
-    ) { } state check_psu_writes
+    when(check_psu_tolerance == 1) { 
+
+    } state check_psu_writes
 
   }
 
@@ -58,6 +49,8 @@ ss zero_field_setpoint_readback_diagnostics
         //   /* If we get to this state, there has been no error */
         //   PVPUT(status, ZF_STAT_NO_ERROR);   
         // }
+        errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
+		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         
         if (debug) {
           errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
@@ -66,11 +59,11 @@ ss zero_field_setpoint_readback_diagnostics
       } state idle
       
       when(delay(read_timeout)) {
-          int incremented_tolerance_errors = pvGet(tolerance_errors) + 1;
-          PVPUT(tolerance_errors, incremented_tolerance_errors);
-		  report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
-		  report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
-		  report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
+          errlogSevPrintf(errlogInfo, "read timeout\n");
+          PVPUT(tolerance_errors, pvGet(tolerance_errors) + 1);
+		      report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
+		      report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
+		      report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
       } state idle
   }
 

--- a/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
+++ b/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
@@ -62,8 +62,8 @@ ss zero_field_setpoint_readback_diagnostics
       
       when(delay(read_timeout)) {
           errlogSevPrintf(errlogInfo, "read timeout\n");
-          new_tolerance_errors = pvGet(tolerance_errors) + 1;
-          PVPUT(tolerance_errors,  new_tolerance_errors);
+          tolerance_errors += 1;
+          pvPut(tolerance_errors);
 		      report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
 		      report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
 		      report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);

--- a/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
+++ b/zfcntrlSup/zero_field_setpoint_readback_diagnostics.st
@@ -19,7 +19,7 @@ option +s;
 
   /* Some necessary function forward-declarations - for implementations see end of file. */
   static int is_within_tolerance(double setpoint, double readback, double tolerance);
-  static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance);
+  static void report_tolerance_error(const char* axis, double sp, double sp_rpv, double tolerance, double timeout);
 
   int new_tolerance_errors = 0;
 }%
@@ -39,15 +39,18 @@ ss zero_field_setpoint_readback_diagnostics
   }
 
   state check_psu_writes {  
-    entry {
-      PVPUT(check_psu_tolerance, 0);
-    }
-
     when(
         is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
         is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
         is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
       ) {
+
+        // if (_output_on_limit) {
+        //   PVPUT(status, ZF_STAT_PSU_ON_LIMITS);
+        // } else {
+        //   /* If we get to this state, there has been no error */
+        //   PVPUT(status, ZF_STAT_NO_ERROR);   
+        // }
         errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
 		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         
@@ -56,15 +59,15 @@ ss zero_field_setpoint_readback_diagnostics
 		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         }
       } state idle
-
-    when(check_psu_tolerance == 1) { 
-        errlogSevPrintf(errlogInfo, "Setpoint-readback failed to get within tolerance of setpoint before a new setpoint was set\n");
-        tolerance_errors += 1;
-        pvPut(tolerance_errors);
-		    report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance);
-		    report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance);
-		    report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance);
-    } state check_psu_writes
+      
+      when(delay(read_timeout)) {
+          errlogSevPrintf(errlogInfo, "read timeout\n");
+          tolerance_errors += 1;
+          pvPut(tolerance_errors);
+		      report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
+		      report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
+		      report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
+      } state idle
   }
 
 }
@@ -81,11 +84,11 @@ ss zero_field_setpoint_readback_diagnostics
   /**
    * Report error if axis out of tolerance
    */
-    static void report_tolerance_error(const char* axis, double sp, double sp_rbv, double tolerance)
+    static void report_tolerance_error(const char* axis, double sp, double sp_rbv, double tolerance, double timeout)
     {
         if (!is_within_tolerance(sp, sp_rbv, tolerance)) {
-            errlogSevPrintf(errlogMajor, "%s: %s Power supply write failed to get within tolerance %f: SP=%f SP:RBV=%f error=%f\n",
-                          PROGRAM_NAME, axis, tolerance, sp, sp_rbv, sp - sp_rbv);
+            errlogSevPrintf(errlogMajor, "%s: %s Power supply write failed to get within tolerance %f: SP=%f SP:RBV=%f error=%f Timeout=%f\n",
+                          PROGRAM_NAME, axis, tolerance, sp, sp_rbv, sp - sp_rbv, timeout);
         }
     }
 }%

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -85,6 +85,7 @@ PV(int, output_psu_z_mode_sp, "{P}OUTPUT:Z:MODE:SP", NoMon);
 
 /* Power supply write tolerance */
 PV(double, output_psu_tolerance, "{P}OUTPUT:PSU_WRITE_TOLERANCE", Monitor);
+PV(int, tolerance_errors, "{P}TOLERANCE_ERRORS", Monitor);
 
 /* Power supply requested voltage limits */
 PV(double, requested_x_volt_limit, "{P}OUTPUT:X:_VOLT_LIMIT", Monitor);

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -25,9 +25,9 @@ PV(int, output_psu_y_sevr, "{P}OUTPUT:Y:CURR.SEVR", Monitor);
 PV(int, output_psu_z_sevr, "{P}OUTPUT:Z:CURR.SEVR", Monitor);
 
 /* Power supply current setpoints */
-PV(double, output_psu_x_sp, "{P}OUTPUT:X:CURR:SP", NoMon);
-PV(double, output_psu_y_sp, "{P}OUTPUT:Y:CURR:SP", NoMon);
-PV(double, output_psu_z_sp, "{P}OUTPUT:Z:CURR:SP", NoMon);
+PV(double, output_psu_x_sp, "{P}OUTPUT:X:CURR:SP", Monitor);
+PV(double, output_psu_y_sp, "{P}OUTPUT:Y:CURR:SP", Monitor);
+PV(double, output_psu_z_sp, "{P}OUTPUT:Z:CURR:SP", Monitor);
 PV(int, output_psu_x_sp_sevr, "{P}OUTPUT:X:CURR:SP.SEVR", Monitor);
 PV(int, output_psu_y_sp_sevr, "{P}OUTPUT:Y:CURR:SP.SEVR", Monitor);
 PV(int, output_psu_z_sp_sevr, "{P}OUTPUT:Z:CURR:SP.SEVR", Monitor);

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -86,6 +86,7 @@ PV(int, output_psu_z_mode_sp, "{P}OUTPUT:Z:MODE:SP", NoMon);
 /* Power supply write tolerance */
 PV(double, output_psu_tolerance, "{P}OUTPUT:PSU_WRITE_TOLERANCE", Monitor);
 PV(int, tolerance_errors, "{P}TOLERANCE_ERRORS", Monitor);
+PV(int, check_psu_tolerance, "{P}CHECK_PSU_TOLERANCE", Monitor);
 
 /* Power supply requested voltage limits */
 PV(double, requested_x_volt_limit, "{P}OUTPUT:X:_VOLT_LIMIT", Monitor);

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -288,3 +288,15 @@ record(longout, "$(P)TOLERANCE_ERRORS") {
     info(archive, "5.0 VAL")
     info(interest, "LOW")
 }
+
+record(bo, "$(P)CHECK_PSU_TOLERANCE") {
+    field(DESC, "trigger to check psu tolerance")
+    field(VAL, "0")
+    field(ZNAM, "No trigger")
+    field(ONAM, "Trigger")
+    field(EGU, "")
+
+    info(archive, "5.0 VAL")
+    info(interest, "LOW")
+}
+

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -279,3 +279,12 @@ record(calc, "$(P)FIELD:MAGNITUDE:MEAS") {
   info(interest, "HIGH")
   field(ASG, "READONLY")
 }
+
+record(longout, "$(P)TOLERANCE_ERRORS") {
+    field(DESC, "Tolerance errors count since IOC start")
+    field(VAL, "0")
+    field(EGU, "")
+
+    info(archive, "5.0 VAL")
+    info(interest, "LOW")
+}

--- a/zfcntrlSup/zfcntrl.dbd
+++ b/zfcntrlSup/zfcntrl.dbd
@@ -1,1 +1,2 @@
 registrar(zero_fieldRegistrar)
+registrar(zero_field_setpoint_readback_diagnosticsRegistrar)


### PR DESCRIPTION
One possible solution for: https://github.com/ISISComputingGroup/IBEX/issues/6722

Instead of waiting for the readback to be within tolerance trigger a check in a separate state machine that tallies up tolerance errors.