### PR TITLE
Ticket6722 attempt2 zf remove wait for tolerance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "*.protocol": "proto",
+        "MacJenkinsfile": "groovy",
+        "*.st": "c"
+    }
+}

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -334,9 +334,9 @@ ss zero_field
 		                PROGRAM_NAME, coerced_x, coerced_y, coerced_z); 
       }
       if (
-        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
-        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
-        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
+        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_x_tolerance) &&
+        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_y_tolerance) &&
+        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_z_tolerance)
       ) {
         if (debug) {
           errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
@@ -344,9 +344,9 @@ ss zero_field
         }
         PVPUT(memory_entry, 100);
       } else {
-        report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
-        report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
-        report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
+        report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_x_tolerance, read_timeout);
+        report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_y_tolerance, read_timeout);
+        report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_z_tolerance, read_timeout);
         PVPUT(memory_entry, 0);
       }
       PVPUT(output_psu_x_sp, coerced_x);
@@ -362,9 +362,9 @@ ss zero_field
       }
       
       when(
-        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
-        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
-        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
+        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_x_tolerance) &&
+        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_y_tolerance) &&
+        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_z_tolerance)
       ) {
                 
         if (_output_on_limit) {
@@ -382,9 +382,9 @@ ss zero_field
       
       when(delay(read_timeout)) {
           PVPUT(status, ZF_STAT_PSU_WRITE_FAILED);
-		  report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
-		  report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
-		  report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
+		  report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_x_tolerance, read_timeout);
+		  report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_y_tolerance, read_timeout);
+		  report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_z_tolerance, read_timeout);
    
        /* don't go to wait_before_read in this case as we have already waited 5 seconds */
       } state trigger_mag_read

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -333,11 +333,27 @@ ss zero_field
         errlogSevPrintf(errlogInfo, "%s: Writing to power supplies X=%f, Y=%f, Z=%f",
 		                PROGRAM_NAME, coerced_x, coerced_y, coerced_z); 
       }
+      if (
+        is_within_tolerance(output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance) &&
+        is_within_tolerance(output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance) &&
+        is_within_tolerance(output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance)
+      ) {
+        if (debug) {
+          errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
+		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
+        }
+      } else {
+        report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
+        report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
+        report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
+        tolerance_errors += 1;
+        pvPut(tolerance_errors);
+      }
       PVPUT(output_psu_x_sp, coerced_x);
       PVPUT(output_psu_y_sp, coerced_y);
       PVPUT(output_psu_z_sp, coerced_z);
       
-    } state check_psu_writes
+    } state wait_before_read
   }
   
   state check_psu_writes {

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -342,6 +342,8 @@ ss zero_field
           errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
 		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         }
+        tolerance_success += 1;
+        pvPut(tolerance_success);
       } else {
         report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
         report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);

--- a/zfcntrlSup/zero_field.st
+++ b/zfcntrlSup/zero_field.st
@@ -342,14 +342,12 @@ ss zero_field
           errlogSevPrintf(errlogInfo, "%s: power supply writes successful X=%f, Y=%f, Z=%f\n",
 		                  PROGRAM_NAME, output_psu_x_sp_rbv, output_psu_y_sp_rbv, output_psu_z_sp_rbv);
         }
-        tolerance_success += 1;
-        pvPut(tolerance_success);
+        PVPUT(memory_entry, 100);
       } else {
         report_tolerance_error("X", output_psu_x_sp, output_psu_x_sp_rbv, output_psu_tolerance, read_timeout);
         report_tolerance_error("Y", output_psu_y_sp, output_psu_y_sp_rbv, output_psu_tolerance, read_timeout);
         report_tolerance_error("Z", output_psu_z_sp, output_psu_z_sp_rbv, output_psu_tolerance, read_timeout);
-        tolerance_errors += 1;
-        pvPut(tolerance_errors);
+        PVPUT(memory_entry, 0);
       }
       PVPUT(output_psu_x_sp, coerced_x);
       PVPUT(output_psu_y_sp, coerced_y);

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -85,6 +85,7 @@ PV(int, output_psu_z_mode_sp, "{P}OUTPUT:Z:MODE:SP", NoMon);
 
 /* Power supply write tolerance */
 PV(double, output_psu_tolerance, "{P}OUTPUT:PSU_WRITE_TOLERANCE", Monitor);
+PV(long, tolerance_errors, "{P}TOLERANCE_ERRORS", Monitor);
 
 /* Power supply requested voltage limits */
 PV(double, requested_x_volt_limit, "{P}OUTPUT:X:_VOLT_LIMIT", Monitor);

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -85,6 +85,9 @@ PV(int, output_psu_z_mode_sp, "{P}OUTPUT:Z:MODE:SP", NoMon);
 
 /* Power supply write tolerance */
 PV(double, output_psu_tolerance, "{P}OUTPUT:PSU_WRITE_TOLERANCE", Monitor);
+PV(double, output_psu_x_tolerance, "{P}OUTPUT:X:PSU_WRITE_TOLERANCE", Monitor);
+PV(double, output_psu_y_tolerance, "{P}OUTPUT:Y:PSU_WRITE_TOLERANCE", Monitor);
+PV(double, output_psu_z_tolerance, "{P}OUTPUT:Z:PSU_WRITE_TOLERANCE", Monitor);
 PV(long, memory_entry, "{P}MEMORY_ENTRY", Monitor);
 
 /* Power supply requested voltage limits */

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -86,6 +86,7 @@ PV(int, output_psu_z_mode_sp, "{P}OUTPUT:Z:MODE:SP", NoMon);
 /* Power supply write tolerance */
 PV(double, output_psu_tolerance, "{P}OUTPUT:PSU_WRITE_TOLERANCE", Monitor);
 PV(long, tolerance_errors, "{P}TOLERANCE_ERRORS", Monitor);
+PV(long, tolerance_success, "{P}TOLERANCE_SUCCESS", Monitor);
 
 /* Power supply requested voltage limits */
 PV(double, requested_x_volt_limit, "{P}OUTPUT:X:_VOLT_LIMIT", Monitor);

--- a/zfcntrlSup/zf_pv_definitions.h
+++ b/zfcntrlSup/zf_pv_definitions.h
@@ -85,8 +85,7 @@ PV(int, output_psu_z_mode_sp, "{P}OUTPUT:Z:MODE:SP", NoMon);
 
 /* Power supply write tolerance */
 PV(double, output_psu_tolerance, "{P}OUTPUT:PSU_WRITE_TOLERANCE", Monitor);
-PV(long, tolerance_errors, "{P}TOLERANCE_ERRORS", Monitor);
-PV(long, tolerance_success, "{P}TOLERANCE_SUCCESS", Monitor);
+PV(long, memory_entry, "{P}MEMORY_ENTRY", Monitor);
 
 /* Power supply requested voltage limits */
 PV(double, requested_x_volt_limit, "{P}OUTPUT:X:_VOLT_LIMIT", Monitor);

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -301,13 +301,13 @@ record(longout, "$(P)TOLERANCE_SUCCESS") {
 record(calc, "$(P)TOLERANCE_SUCCESS_PERCENT") {
     field(DESC, "% of times sprbv did reach sp")
     field(VAL, "0")
-    field(EGU, "")
+    field(EGU, "%")
 
     field(INPA, "$(P)TOLERANCE_SUCCESS CP MS")
     field(INPB, "$(P)TOLERANCE_ERRORS CP MS")
 
-    field(CALC, "A / (A + B)")
-    
-    info(archive, "5.0 VAL")
+    field(CALC, "(A / (A + B)) * 100")
+
+    info(archive, "5.0 VAL"))
     info(interest, "LOW")
 }

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -280,34 +280,33 @@ record(calc, "$(P)FIELD:MAGNITUDE:MEAS") {
   field(ASG, "READONLY")
 }
 
-record(longout, "$(P)TOLERANCE_ERRORS") {
-    field(DESC, "Times sprbv didn't reach sp")
-    field(VAL, "0")
-    field(EGU, "")
+record(longout, "$(P)MEMORY_ENTRY") {
+  field(DESC, "Times sprbv did reach sp")
+  field(VAL, "0")
+  field(EGU, "")
 
-    info(archive, "5.0 VAL")
-    info(interest, "LOW")
+  info(archive, "5.0 VAL")
+  info(interest, "LOW")
 }
 
-record(longout, "$(P)TOLERANCE_SUCCESS") {
-    field(DESC, "Times sprbv did reach sp")
-    field(VAL, "0")
-    field(EGU, "")
 
-    info(archive, "5.0 VAL")
-    info(interest, "LOW")
+record(compress, "$(P)READBACK_MEMORY") {
+  field(INP, "$(P)MEMORY_ENTRY MSS")
+  field(ALG, "Circular Buffer")
+  field(NSAM, "1000")
+  field(FLNK, "$(P)TOLERANCE_SUCCESS_PERCENT")
+  
+  info(archive, "5.0 VAL")
+  info(interest, "LOW")
 }
 
-record(calc, "$(P)TOLERANCE_SUCCESS_PERCENT") {
-    field(DESC, "% of times sprbv did reach sp")
-    field(VAL, "0")
-    field(EGU, "%")
-
-    field(INPA, "$(P)TOLERANCE_SUCCESS CP MS")
-    field(INPB, "$(P)TOLERANCE_ERRORS CP MS")
-
-    field(CALC, "(A / (A + B)) * 100")
-
-    info(archive, "5.0 VAL"))
-    info(interest, "LOW")
+record(compress, "$(P)TOLERANCE_SUCCESS_PERCENT") {
+  field(INP, "$(P)READBACK_MEMORY MSS")
+  field(ALG, "N to 1 Average")
+  field(NSAM, "1")
+  field(N, "1000")
+  field(EGU, "%")
+  
+  info(archive, "5.0 VAL")
+  info(interest, "LOW")
 }

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -284,6 +284,7 @@ record(longout, "$(P)MEMORY_ENTRY") {
   field(DESC, "Times sprbv did reach sp")
   field(VAL, "0")
   field(EGU, "")
+  field(FLNK, "$(P)READBACK_MEMORY")
 
   info(archive, "5.0 VAL")
   info(interest, "LOW")

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -281,10 +281,33 @@ record(calc, "$(P)FIELD:MAGNITUDE:MEAS") {
 }
 
 record(longout, "$(P)TOLERANCE_ERRORS") {
-    field(DESC, "Tolerance errors count since IOC start")
+    field(DESC, "Times sprbv didn't reach sp")
     field(VAL, "0")
     field(EGU, "")
 
+    info(archive, "5.0 VAL")
+    info(interest, "LOW")
+}
+
+record(longout, "$(P)TOLERANCE_SUCCESS") {
+    field(DESC, "Times sprbv did reach sp")
+    field(VAL, "0")
+    field(EGU, "")
+
+    info(archive, "5.0 VAL")
+    info(interest, "LOW")
+}
+
+record(calc, "$(P)TOLERANCE_SUCCESS_PERCENT") {
+    field(DESC, "% of times sprbv did reach sp")
+    field(VAL, "0")
+    field(EGU, "")
+
+    field(INPA, "$(P)TOLERANCE_SUCCESS CP MS")
+    field(INPB, "$(P)TOLERANCE_ERRORS CP MS")
+
+    field(CALC, "A / (A + B)")
+    
     info(archive, "5.0 VAL")
     info(interest, "LOW")
 }

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -279,3 +279,12 @@ record(calc, "$(P)FIELD:MAGNITUDE:MEAS") {
   info(interest, "HIGH")
   field(ASG, "READONLY")
 }
+
+record(longout, "$(P)TOLERANCE_ERRORS") {
+    field(DESC, "Tolerance errors count since IOC start")
+    field(VAL, "0")
+    field(EGU, "")
+
+    info(archive, "5.0 VAL")
+    info(interest, "LOW")
+}

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -245,7 +245,7 @@ alias("$(P)P:FEEDBACK", "$(P)P:FEEDBACK:SP")
 record(ao, "$(P)OUTPUT:PSU_WRITE_TOLERANCE") {
   field(DESC, "Output power supply write tolerance")
   field(EGU, "A")
-  field(VAL, "0.0002")
+  field(VAL, "0.0012")
   field(PINI, "YES")
   
   info(archive, "5.0 VAL")

--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -294,7 +294,7 @@ record(longout, "$(P)MEMORY_ENTRY") {
 record(compress, "$(P)READBACK_MEMORY") {
   field(INP, "$(P)MEMORY_ENTRY MSS")
   field(ALG, "Circular Buffer")
-  field(NSAM, "1000")
+  field(NSAM, "100")
   field(FLNK, "$(P)TOLERANCE_SUCCESS_PERCENT")
   
   info(archive, "5.0 VAL")
@@ -305,7 +305,7 @@ record(compress, "$(P)TOLERANCE_SUCCESS_PERCENT") {
   field(INP, "$(P)READBACK_MEMORY MSS")
   field(ALG, "N to 1 Average")
   field(NSAM, "1")
-  field(N, "1000")
+  field(N, "100")
   field(EGU, "%")
   
   info(archive, "5.0 VAL")

--- a/zfcntrlSup/zfcntrl_axis.template
+++ b/zfcntrlSup/zfcntrl_axis.template
@@ -217,3 +217,13 @@ record(ao, "$(P)OUTPUT:$(AXIS):_VOLT_LIMIT") {
   
   info(archive, "5.0 VAL")
 }
+
+record(ao, "$(P)OUTPUT:$(AXIS):PSU_WRITE_TOLERANCE") {
+  field(DESC, "Output power supply write tolerance")
+  field(EGU, "A")
+  field(VAL, "0.0002")
+  field(PINI, "YES")
+  
+  info(archive, "5.0 VAL")
+  info(interest, "LOW")
+}


### PR DESCRIPTION
A second (better) solution for https://github.com/ISISComputingGroup/IBEX/issues/6722

Instead of waiting for the setpoint readback to be within tolerance of the setpoint, check before setting a setpoint that the last was in tolerance. Calculate the percentage of setpoints that have reached tolerance before another setpoint was set.