### PR TITLE
Set tolerance to 0.0012 as default

### DIFF
--- a/zfcntrlSup/zfcntrl.db
+++ b/zfcntrlSup/zfcntrl.db
@@ -245,7 +245,7 @@ alias("$(P)P:FEEDBACK", "$(P)P:FEEDBACK:SP")
 record(ao, "$(P)OUTPUT:PSU_WRITE_TOLERANCE") {
   field(DESC, "Output power supply write tolerance")
   field(EGU, "A")
-  field(VAL, "0.0002")
+  field(VAL, "0.0012")
   field(PINI, "YES")
   
   info(archive, "5.0 VAL")


### PR DESCRIPTION
Agreed with scientists that 0.0012 should be default as it covers the kepco at the higher current range

https://github.com/ISISComputingGroup/IBEX/issues/6797